### PR TITLE
Allow custom MCP path

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@deco/mcp",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "exports": {
     ".": "./mod.ts",
     "./http": "./mcp/http.ts"

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -51,6 +51,10 @@ export interface Options<TManifest extends AppManifest> {
   exclude?: Array<keyof (TManifest["actions"] & TManifest["loaders"])>;
   blocks?: Array<keyof TManifest>;
   basePath?: string;
+  /**
+   * Custom path for MCP messages endpoint. Defaults to /mcp/messages if not provided.
+   */
+  mcpPath?: string;
   middlewares?: {
     listTools?: ListToolsMiddleware[];
     callTool?: CallToolMiddleware[];
@@ -328,7 +332,8 @@ export function mcpServer<TManifest extends AppManifest>(
     }
 
     // Main message endpoint - handles both stateless requests and SSE upgrades
-    if (path === `${options?.basePath ?? ""}${MESSAGES_ENDPOINT}`) {
+    const mcpPath = options?.mcpPath ?? MESSAGES_ENDPOINT;
+    if (path === `${options?.basePath ?? ""}${mcpPath}`) {
       // For stateless transport
       const transport = new HttpServerTransport();
       await mcp.server.connect(transport);


### PR DESCRIPTION
Some MCP server docs mention using `/mcp`.

I want to allow sites to do that.

<img width="792" alt="image" src="https://github.com/user-attachments/assets/1a9651e7-4625-4c25-aa6d-593e227962a0" />
