### PR TITLE
fix: prevent transport.close on GET requests for SSE connections

### DIFF
--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -800,7 +800,12 @@ export function mcpServer<TManifest extends AppManifest>(
       });
 
       const response = await handleMessage();
-      transport.close(); // Close the transport after handling the message
+      
+      // Do not close transport on GET requests (SSE may require longer connections)
+      if (c.req.method !== "GET") {
+        transport.close();
+      }
+      
       return response;
     }
     await next();


### PR DESCRIPTION
## Summary
- Fixed the `/mcp/messages` endpoint to not close transport connections on GET requests
- SSE (Server-Sent Events) requires long-lived connections that should not be closed immediately

## Changes
- Added conditional check to only close transport on non-GET requests
- GET requests (SSE) now keep the connection open as expected

## Test plan
- [ ] Test SSE connections remain open on GET requests
- [ ] Test POST requests still close transport properly
- [ ] Verify no connection leaks or memory issues


Made with [Cursor](https://cursor.com)